### PR TITLE
fix:docker compose udp publish ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,8 @@ services:
       - "mongodb:mongodb.service"
     ports:
       - "9000:9000"
-      - "12201/udp:12201/udp"
-      - "1514/udp:1514/udp"
+      - "12201:12201/udp"
+      - "1514:1514/udp"
 
   # Based on Logspout by Gliderlabs
   # https://github.com/gliderlabs/logspout


### PR DESCRIPTION
issue : 
services.graylog.ports contain an invalid type, it should be a number or an object

description ;
when you try to start the dokcer-compose.yml file you get the above error which is referring the UDP ports that's been published by Graylog service.